### PR TITLE
chore: remove deprecated productionMode configuration

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,6 @@
                     <frontendDirectory>target</frontendDirectory>
                     <reactEnable>false</reactEnable>
                     <optimizeBundle>false</optimizeBundle>
-                    <productionMode>true</productionMode>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
productionMode configuration is deprecated and has no effect anymore, other than printing a log warning message.
`build-frontend` implicitly builds for production.